### PR TITLE
calendar.rbを作成

### DIFF
--- a/ruby/calendar.rb
+++ b/ruby/calendar.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'date'
+
+opt = OptionParser.new
+
+options = { month: Date.today.month }
+
+# 引数の受け取り
+opt.on('-m [month]', Integer) do |month|
+  if month >= 1 && month <= 12
+    options[:month] = month
+  else
+    puts "#{month} is neither a month number (1..12) nor a name"
+    exit
+  end
+end
+
+begin
+  opt.parse!(ARGV)
+rescue NoMethodError
+  puts 'Only integers between 1 and 12'
+  exit
+end
+
+# データの用意
+year = Date.today.year
+header = Date.new(year, options[:month]).strftime('%-m月 %Y')
+start_day = Date.new(year, options[:month], 1)
+end_day = Date.new(year, options[:month], -1)
+wdays = %w[月 火 水 木 金 土 日]
+wday = start_day.wday
+
+# カレンダー出力
+puts header.center(20)
+puts wdays.join(' ')
+print '   ' * (start_day.wday - 1)
+
+(1..end_day.day).each do |date|
+  print format('%2s', date.to_s)
+  print ' '
+  puts '' if (wday % 7).zero?
+  wday += 1
+end
+
+puts


### PR DESCRIPTION
## 課題のリンク



## やったこと

calendar.rbの作成


## 動作確認方法

`# ruby calendar.rb -m 1`
`# ruby calendar.rb`

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）
### rubocop通りに修正すると 引数にStringを指定した場合にArgumentErrorで例外補足してくれない
```
opt.on('-m [month]', Integer) {|month|
  if 1 <= month && month <= 12
    options[:month] = month
  else
    puts "#{month} is neither a month number (1..12) nor a name"
    exit
  end
}
```
上記は`rubocop -a`を通す前の引数チェックをする際のコードです。
この時、`ruby calendar -m e(String)`を指定するとArgumentErrorを補足してrescueの処理を行うのですが
rubocopを通して修正した下記コードでは NoMethodErrorとして捕捉されてしまいます。
```diff
opt.on('-m [month]', Integer) do |month|
-   if 1 <= month && month <= 12
+  if month >= 1 && month <= 12
    options[:month] = month
  else
    puts "#{month} is neither a month number (1..12) nor a name"
    exit
  end
end
```
不等号の順番が原因でしょうか。
調べるとNoMethodErrorとなるのは 引数がStringであるのに対し、 `>`はIntegerに対して作用するものだから
同エラーが出力されると理解しましたがその認識で良いでしょうか。